### PR TITLE
Fix NRE in ItemTool_UpdateInteract_Postfix

### DIFF
--- a/PickUpChert/patches/ChertItemPatch.cs
+++ b/PickUpChert/patches/ChertItemPatch.cs
@@ -211,7 +211,7 @@ namespace PickUpChert {
         [HarmonyPostfix]
         [HarmonyPatch(typeof(ItemTool), nameof(ItemTool.UpdateInteract))]
         public static void ItemTool_UpdateInteract_Postfix(ItemTool __instance) {
-            if(!__instance._heldItem && ChertItem.Instance.Brought) {
+            if(!__instance._heldItem && ChertItem.Instance && ChertItem.Instance.Brought) {
                 __instance._heldItem = ChertItem.Instance;
             }
         }


### PR DESCRIPTION
```
NullReferenceException: Object reference not set to an instance of an object
Stacktrace: PickUpChert.ChertItemPatch.ItemTool_UpdateInteract_Postfix (ItemTool __instance) (at <3bd43fea0ae64dc8848bde32d5504bd4>:0)
(wrapper dynamic-method) ItemTool.DMD<ItemTool::UpdateInteract>(ItemTool,FirstPersonManipulator,bool)
ToolModeSwapper.Update () (at <154a8af147d944cea3374a4b992752d0>:0)
```